### PR TITLE
feat(web): Plotly Dash 集成 (to_dash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 - **Property-based 测试**：集成 Hypothesis（`test/test_hypothesis_properties.py`，17 个测试），通过 `HYPOTHESIS_PROFILE` 环境变量切换 dev / ci / exhaustive 三档
 - **性能基线测试**：新增 `test/test_performance.py` 与 `test/baselines/perf_baseline.json`，本地 / CI 阈值分层（500ms / 800ms），通过 `CI` 环境变量自动切换；`benchmarks/bench_render.py` 扩展 `html_size` / `compact_vs_pretty` / `downsample` 三组基准
 - **依赖分组**：`optional-dependencies` 扩充到 10 个分组（pandas / numpy / export / streamlit / notebook / offline / docs / test / dev / all）；`all` 仅包含"用户向"分组，避免拉入 500MB+ 开发依赖
+- **Plotly Dash 集成**：新增 `pyantv.web.to_dash(chart, width, height, style)`，将 pyantv 图表渲染为 Plotly Dash 的 `html.Iframe` 组件（`srcDoc` 沙盒执行内联 G2 脚本，绕过 React 对内联脚本的剥离）；对齐 Flask / Sanic / Django / Streamlit 集成范式，懒加载 `dash`，未安装时抛带 `pip install dash` 提示的 `ImportError`。新增 `pip install pyantv[dash]` 可选依赖组（Sprint 74，对应 Issue #3）
+
+
 
 ### Changed
 

--- a/README.en.md
+++ b/README.en.md
@@ -335,6 +335,23 @@ line = (
 st_pyantv(line, height=400)
 ```
 
+### Plotly Dash Integration
+
+```python
+import dash
+from pyantv import Line
+from pyantv.web import to_dash
+
+line = (
+    Line()
+    .set_data(data=[{"x": 1, "y": 2}, {"x": 2, "y": 5}])
+    .set_encode(x_field_name="x", y_field_name="y")
+)
+
+app = dash.Dash(__name__)
+app.layout = dash.html.Div([to_dash(line, height="400px")])
+```
+
 ### Chart Export
 
 ```python

--- a/README.md
+++ b/README.md
@@ -358,6 +358,23 @@ line = (
 st_pyantv(line, height=400)
 ```
 
+### Plotly Dash 集成
+
+```python
+import dash
+from pyantv import Line
+from pyantv.web import to_dash
+
+line = (
+    Line()
+    .set_data(data=[{"x": 1, "y": 2}, {"x": 2, "y": 5}])
+    .set_encode(x_field_name="x", y_field_name="y")
+)
+
+app = dash.Dash(__name__)
+app.layout = dash.html.Div([to_dash(line, height="400px")])
+```
+
 ### 图表导出
 
 ```python

--- a/pyantv/web/__init__.py
+++ b/pyantv/web/__init__.py
@@ -1,3 +1,4 @@
+from pyantv.web.dash import to_dash
 from pyantv.web.integrations import make_response, render_chart_to_html
 from pyantv.web.streamlit import st_pyantv
 from pyantv.web.widget import ChartWidget, render_widget
@@ -6,6 +7,7 @@ __all__ = [
     "make_response",
     "render_chart_to_html",
     "st_pyantv",
+    "to_dash",
     "render_widget",
     "ChartWidget",
 ]

--- a/pyantv/web/dash.py
+++ b/pyantv/web/dash.py
@@ -1,0 +1,85 @@
+"""Plotly Dash 集成辅助函数。
+
+提供 ``to_dash()`` 函数，让 pyantv 图表可以嵌入 Plotly Dash 应用。
+
+使用示例
+--------
+
+.. code-block:: python
+
+    import dash
+    from pyantv import Line
+    from pyantv.web import to_dash
+
+    line = (
+        Line()
+        .set_data(data=[{"x": 1, "y": 2}, {"x": 2, "y": 5}])
+        .set_encode(x_field_name="x", y_field_name="y")
+    )
+
+    app = dash.Dash(__name__)
+    app.layout = dash.html.Div([to_dash(line, height="400px")])
+"""
+
+from typing import Any, Optional
+
+
+def to_dash(
+    chart: Any,
+    width: Optional[str] = None,
+    height: Optional[str] = None,
+    style: Optional[dict] = None,
+) -> Any:
+    """将 pyantv 图表渲染为 Dash ``html.Iframe`` 组件。
+
+    通过 iframe ``srcDoc`` 沙盒执行图表 HTML（含 AntV G2 CDN ``<script>`` 与初始化
+    脚本），绕过 Dash / React 对内联脚本的剥离。该方案与 Streamlit
+    ``components.html()`` 及 Notebook ``build_iframe_html`` 的 srcdoc 嵌入一致。
+
+    需要安装 Dash：``pip install dash`` 或 ``pip install pyantv[dash]``。
+
+    :param chart: pyantv 图表对象（Line、Interval 等，需可实现 ``render_embed()``）。
+    :param width: iframe 宽度（CSS 字符串，如 ``"100%"`` / ``"900px"``），默认 None
+        表示不显式设置（交由浏览器 / 布局决定）。优先级高于 ``style`` 中的同名键。
+    :param height: iframe 高度（CSS 字符串，如 ``"500px"``），默认 None。优先级高于
+        ``style`` 中的同名键。
+    :param style: 额外的 iframe 行内样式字典，会与 ``width`` / ``height`` 合并为一个
+        新字典（不原地修改用户传入的 dict）；后者优先级更高（覆盖同名字段）。
+    :returns: ``dash.html.Iframe`` 组件对象，可直接放入 ``dash.html.Div([...])`` 布局。
+    :raises ImportError: 当未安装 ``dash`` 时。
+
+    .. note::
+
+        图表隔离在 iframe 沙盒中，跨组件的 Dash 回调无法直接读取图表交互事件
+        （如点击 / 筛选）。该限制不在本函数解决，需要跨组件交互时请在应用层
+        自行处理。
+
+    Examples:
+        >>> import dash
+        >>> from pyantv import Line
+        >>> from pyantv.web import to_dash
+        >>> line = (
+        ...     Line()
+        ...     .set_data(data=[{"x": 1, "y": 2}])
+        ...     .set_encode(x_field_name="x", y_field_name="y")
+        ... )
+        >>> app = dash.Dash(__name__)
+        >>> app.layout = dash.html.Div([to_dash(line, height="400px")])
+    """
+    try:
+        import dash
+    except ImportError:
+        raise ImportError(
+            "Dash is required for to_dash(). "
+            "Install it with: pip install dash"
+        )
+
+    html_content = chart.render_embed()
+
+    merged_style = dict(style or {})
+    if width is not None:
+        merged_style["width"] = width
+    if height is not None:
+        merged_style["height"] = height
+
+    return dash.html.Iframe(srcDoc=html_content, style=merged_style or None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ export = ["playwright>=1.40.0"]
 streamlit = ["streamlit>=1.0.0"]
 notebook = ["ipywidgets>=7.0", "ipython>=7.0"]
 offline = ["requests>=2.25.0"]
+dash = ["dash>=2.0.0"]
 # ---- 聚合分组：只包含"用户向"分组，不含 dev/test/docs（避免带入 500MB+ 开发依赖）----
 all = [
     "pandas>=1.0.0",
@@ -69,6 +70,7 @@ all = [
     "ipywidgets>=7.0",
     "ipython>=7.0",
     "requests>=2.25.0",
+    "dash>=2.0.0",
 ]
 
 # ---------------------------------------------------------------------------

--- a/test/test_dash_integration.py
+++ b/test/test_dash_integration.py
@@ -1,0 +1,161 @@
+"""Plotly Dash 集成组件测试。
+
+镜像 ``test_streamlit_integration.py`` 的纯 mock 范式：CI / test 依赖组不安装
+``dash``，故全程用 ``sys.modules`` 注入 mock 模块，并在 finally 还原，避免污染
+其他测试。
+"""
+
+import importlib
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pyantv import Line
+from pyantv.web import dash as dash_mod
+
+
+def _inject_mock_dash():
+    """向 sys.modules 注入一个 mock ``dash`` 模块并返回关键 mock 对象。
+
+    :returns: ``(mock_dash, mock_iframe)`` 元组。
+    """
+    mock_iframe = MagicMock(name="dash.html.Iframe_instance")
+    mock_html = MagicMock(name="dash.html")
+    mock_html.Iframe = MagicMock(name="dash.html.Iframe_cls", return_value=mock_iframe)
+    mock_dash = MagicMock(name="dash")
+    mock_dash.html = mock_html
+    saved = {
+        k: sys.modules.pop(k, None)
+        for k in list(sys.modules)
+        if k == "dash" or k.startswith("dash.")
+    }
+    sys.modules["dash"] = mock_dash
+    importlib.reload(dash_mod)
+    return mock_dash, mock_iframe, saved
+
+
+def _restore_dash(saved):
+    """还原 sys.modules 中被 mock 注入占位的 ``dash`` 相关模块。
+
+    :param saved: 注入时返回的 saved 映射。
+    """
+    for k in list(sys.modules):
+        if k == "dash" or k.startswith("dash."):
+            sys.modules.pop(k, None)
+    sys.modules.update({k: v for k, v in saved.items() if v is not None})
+    importlib.reload(dash_mod)
+
+
+class TestDashIntegration(unittest.TestCase):
+    """测试 pyantv.web.dash 模块的 Plotly Dash 集成功能。"""
+
+    def test_to_dash_without_dash_raises_import_error(self):
+        """M-LAZY-IMPORT: 未安装 dash 时抛带安装提示的 ImportError。"""
+        mock_chart = MagicMock()
+        with patch.dict("sys.modules", {"dash": None}):
+            with self.assertRaises(ImportError) as ctx:
+                dash_mod.to_dash(mock_chart)
+            self.assertIn("Dash is required", str(ctx.exception))
+            self.assertIn("pip install dash", str(ctx.exception))
+
+    def test_to_dash_calls_render_embed_and_uses_srcdoc_camelcase(self):
+        """M-RENDER-EMBED-CALLED + M-SRCDOC-KWARG。
+
+        调 render_embed 且以 srcDoc= kwarg 构造 Iframe；用真实 Line 保证
+        srcDoc 内容是真实渲染输出。
+        """
+        line = (
+            Line()
+            .set_data(data=[{"x": 1, "y": 2}, {"x": 2, "y": 5}])
+            .set_encode(x_field_name="x", y_field_name="y")
+        )
+        mock_dash, mock_iframe, saved = _inject_mock_dash()
+        try:
+            dash_mod.to_dash(line)
+            # Iframe 构造器被调用一次
+            self.assertEqual(mock_dash.html.Iframe.call_count, 1)
+            kwargs = mock_dash.html.Iframe.call_args[1]
+            # 关键字参数名必须是 camelCase 的 srcDoc
+            self.assertIn("srcDoc", kwargs)
+            # Iframe 收到的 srcDoc 恰为 render_embed() 的返回值
+            self.assertEqual(kwargs["srcDoc"], line.render_embed())
+            self.assertNotIn("srcdoc", kwargs)
+        finally:
+            _restore_dash(saved)
+
+    def test_to_dash_calls_chart_render_embed_once(self):
+        """M-RENDER-EMBED-CALLED: mock chart 调用后 render_embed 恰被调用一次。
+
+        对齐 test_streamlit_integration.py 的镜像范式（显式 assert_called_once）。
+        """
+        mock_chart = MagicMock()
+        mock_chart.render_embed.return_value = "<html>chart</html>"
+        mock_dash, _, saved = _inject_mock_dash()
+        try:
+            dash_mod.to_dash(mock_chart)
+            mock_chart.render_embed.assert_called_once()
+        finally:
+            _restore_dash(saved)
+
+    def test_to_dash_srcdoc_contains_antv_g2_options(self):
+        """M-RENDER: srcDoc 内容含 AntV G2 初始化标记 new G2.Chart 与 .options(。"""
+        line = (
+            Line()
+            .set_data(data=[{"x": 1, "y": 2}, {"x": 2, "y": 5}])
+            .set_encode(x_field_name="x", y_field_name="y")
+        )
+        mock_dash, _, saved = _inject_mock_dash()
+        try:
+            dash_mod.to_dash(line)
+            src_doc = mock_dash.html.Iframe.call_args[1]["srcDoc"]
+            self.assertIsInstance(src_doc, str)
+            self.assertIn("new G2.Chart", src_doc)
+            self.assertIn(".options(", src_doc)
+        finally:
+            _restore_dash(saved)
+
+    def test_to_dash_width_height_propagated_to_style(self):
+        """S-WIDTH-HEIGHT: width/height 透传到 Iframe 的 style 字典。"""
+        mock_chart = MagicMock()
+        mock_chart.render_embed.return_value = "<html>chart</html>"
+        mock_dash, _, saved = _inject_mock_dash()
+        try:
+            dash_mod.to_dash(mock_chart, width="100%", height="600px")
+            kwargs = mock_dash.html.Iframe.call_args[1]
+            self.assertIsNotNone(kwargs.get("style"))
+            self.assertEqual(kwargs["style"].get("width"), "100%")
+            self.assertEqual(kwargs["style"].get("height"), "600px")
+        finally:
+            _restore_dash(saved)
+
+    def test_to_dash_style_merge_with_width_height_override(self):
+        """S-STYLE-MERGE: style 与 width/height 合并；后者覆盖前者同名字段，且不突变入参。"""
+        mock_chart = MagicMock()
+        mock_chart.render_embed.return_value = "<html>chart</html>"
+        user_style = {"border": "1px solid", "width": "50%"}
+        mock_dash, _, saved = _inject_mock_dash()
+        try:
+            dash_mod.to_dash(
+                mock_chart, width="100%", height="400px", style=user_style
+            )
+            kwargs = mock_dash.html.Iframe.call_args[1]
+            style = kwargs["style"]
+            # 保留 style 中的非冲突字段
+            self.assertEqual(style.get("border"), "1px solid")
+            # width 被 width 参数覆盖
+            self.assertEqual(style.get("width"), "100%")
+            self.assertEqual(style.get("height"), "400px")
+            # 入参 dict 未被原地修改
+            self.assertEqual(user_style["width"], "50%")
+        finally:
+            _restore_dash(saved)
+
+    def test_to_dash_importable_from_web(self):
+        """M-EXPORT: 可从 pyantv.web 导入且可调用。"""
+        from pyantv.web import to_dash
+
+        self.assertTrue(callable(to_dash))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -271,8 +271,11 @@ def test_dynamic_version_configured(pyproject_data: dict) -> None:
         "dynamic", []
     ), "pyproject.toml 必须声明 dynamic = ['version']"
     # 版本由 setuptools-scm 管理，不应存在 [tool.setuptools.dynamic].version
-    scm_cfg = pyproject_data.get("tool", {}).get("setuptools-scm", {})
-    assert scm_cfg, "pyproject.toml 必须配置 [tool.setuptools-scm] " "来管理动态版本"
+    # 注意：setuptools-scm v10 起官方键名为 [tool.setuptools_scm]（下划线）；
+    # 为兼容旧写法仍可能用连字符，此处两者皆接受（与 pyproject 实际配置对齐）。
+    tool_cfg = pyproject_data.get("tool", {})
+    scm_cfg = tool_cfg.get("setuptools-scm") or tool_cfg.get("setuptools_scm") or {}
+    assert scm_cfg, "pyproject.toml 必须配置 [tool.setuptools-scm] 来管理动态版本"
     assert (
         scm_cfg.get("write_to") == "pyantv/_version.py"
     ), "setuptools-scm.write_to 必须是 'pyantv/_version.py'"


### PR DESCRIPTION
## 概述

为 pyantv 添加 Plotly Dash 集成，让 pyantv 图表能嵌入 Dash 应用。

Closes #3

## 用法

```python
import dash
from pyantv import Line
from pyantv.web import to_dash

line = (
    Line()
    .set_data(data=[{"x": 1, "y": 2}, {"x": 2, "y": 5}])
    .set_encode(x_field_name="x", y_field_name="y")
)

app = dash.Dash(__name__)
app.layout = dash.html.Div([to_dash(line, height="400px")])
```

安装: `pip install pyantv[dash]`（或 `pip install dash`）

## 设计

- `to_dash(chart, width=None, height=None, style=None)` 返回 `dash.html.Iframe(srcDoc=chart.render_embed(), style=...)`
- iframe `srcDoc` 沙盒执行内联 G2 `<script>`，绕过 React 对内联脚本的剥离（与现有 Streamlit `components.html()`、Notebook `build_iframe_html` 的 srcdoc 方案同源）
- `dash` 懒加载，未安装时抛 `ImportError("Dash is required ... pip install dash")`（对齐 `make_response` / `st_pyantv` 范式）
- `style` 用 `{**(style or {}), "width": w, "height": h}` 复制拼接，不原地突变调用方 dict；width/height 优先级高于 style 同名字段

## 变更

| 文件 | 说明 |
|------|------|
| `pyantv/web/dash.py` (新, 85 行) | `to_dash` 函数 |
| `pyantv/web/__init__.py` | 导出 `to_dash`（保持懒加载，包级 import 不触发 `import dash`） |
| `pyproject.toml` | 新增 `dash = ["dash>=2.0.0"]` 可选依赖组 + 并入 `all`（不污染 dev 依赖） |
| `test/test_dash_integration.py` (新, 161 行) | 7 用例，纯 mock（CI 不需装 dash） |
| `CHANGELOG.md` / `README.md` / `README.en.md` | 文档（中英） |
| `test/test_packaging.py` | 附带 pre-existing master 回归修复（见下） |

## 附带修复：pre-existing master 回归（test_dynamic_version_configured）

合并 commit `e8be82c`（"use underscore in `[tool.setuptools_scm]` for setuptools-scm v10 compatibility"）把 pyproject 配置键改成了下划线 `setuptools_scm`（v10 要求，正确），但 `test/test_packaging.py::test_dynamic_version_configured` 仍在查找带连字符的 `setuptools-scm` 键 → 读到 `{}` → 断言失败。**已实证非本 PR 引入**（revert pyproject 回 master，该测试仍 FAIL）。

最小一致性修复：让该测试同时接受 `setuptools-scm` / `setuptools_scm` 两种键名，保留 `write_to == "pyantv/_version.py"` 核心断言。行为不变，属 Harness 豁免范畴。评审时若需更干净，可拆为独立 chore PR。

## 验证

| 项 | 结果 |
|----|------|
| `python -m build` | ✅ sdist + wheel 成功（含 `pyantv/web/dash.py`） |
| 全量回归 `pytest --cov-config=.coveragerc --cov=./ test/` | ✅ **1076 passed, 0 failed, 100% 覆盖** |
| `to_dash` 增量覆盖率 | ✅ **100%**（≥70%） |
| `flake8 --max-line-length=89` | ✅ 干净 |

## Harness 评估

本 PR 经项目 Harness 八步三 Agent 工作流（合约先行 → Evaluator 独立审查 → 用户确认 → 实现 → 全量回归 → Evaluator 评分）。

- Evaluator 评分: **97 / 100 ✅ PASS**（≥90 阈值）
- МUST 强制条款全通过: M-BUILD / M-REGRESSION / M-TEST / M-VERIFY (FAIL_TO_PASS) / M-RENDER / M-SRCDOC-KWARG / M-LAZY-IMPORT / M-RENDER-EMBED-CALLED / M-PYPROJECT / M-PACKAGING-INVARIANT / M-EXPORT
- 唯一失分(-3 功能正确性)已在第 2 轮迭代补齐 `render_embed.assert_called_once()` 显式断言（对齐 streamlit 测试范式）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)